### PR TITLE
Add GUI for Command-line Interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Dependencies:
 - Python 3
 - [uesave-rs](https://github.com/trumank/uesave-rs)
 
+Using the GUI:
+- Open command prompt in folder
+- Run command `python gui.py`
+- Select uesave location and your world save folder
+- Select old GUID and new GUID from the dropdowns
+- Hit the button
+
 Command:    
 `python fix-host-save.py <uesave.exe> <save_path> <new_guid> <old_guid>`    
 `<uesave.exe>` - Path to your uesave.exe    

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,95 @@
+import tkinter as tk
+from tkinter import filedialog, ttk
+import subprocess
+import json
+import os
+
+config_file = 'config.json'
+
+def browse_file(entry):
+    filename = filedialog.askopenfilename()
+    entry.delete(0, tk.END)
+    entry.insert(0, filename)
+    save_config()
+
+def browse_folder(entry):
+    foldername = filedialog.askdirectory()
+    entry.delete(0, tk.END)
+    entry.insert(0, foldername)
+    save_config()
+    update_guid_dropdowns(foldername)
+
+def update_guid_dropdowns(folder_path):
+    players_folder = os.path.join(folder_path, "Players")
+    if os.path.exists(players_folder) and os.path.isdir(players_folder):
+        file_names = [f for f in os.listdir(players_folder) if os.path.isfile(os.path.join(players_folder, f))]
+        combo_new_guid['values'] = file_names
+        combo_old_guid['values'] = file_names
+
+def run_command():
+    uesave_path = entry_uesave.get()
+    save_path = entry_save.get()
+    new_guid = combo_new_guid.get()
+    old_guid = combo_old_guid.get()
+    command = f'python fix-host-save.py "{uesave_path}" "{save_path}" {new_guid} {old_guid}'
+    subprocess.run(command, shell=True)
+
+def save_config():
+    config = {
+        'uesave_path': entry_uesave.get(),
+        'save_path': entry_save.get(),
+        'new_guid': combo_new_guid.get(),
+        'old_guid': combo_old_guid.get()
+    }
+    with open(config_file, 'w') as f:
+        json.dump(config, f)
+
+def on_entry_change(event):
+    save_config()
+
+def load_config():
+    if os.path.exists(config_file):
+        with open(config_file, 'r') as f:
+            config = json.load(f)
+            entry_uesave.insert(0, config.get('uesave_path', ''))
+            entry_save.insert(0, config.get('save_path', ''))
+            update_guid_dropdowns(config.get('save_path', ''))
+            combo_new_guid.set(config.get('new_guid', ''))
+            combo_old_guid.set(config.get('old_guid', ''))
+
+app = tk.Tk()
+app.title("Fix Host Save Command GUI")
+
+# Uesave.exe path
+tk.Label(app, text="Path to uesave.exe:").pack()
+entry_uesave = tk.Entry(app, width=50)
+entry_uesave.pack()
+entry_uesave.bind("<KeyRelease>", on_entry_change)
+button_browse_uesave = tk.Button(app, text="Browse", command=lambda: browse_file(entry_uesave))
+button_browse_uesave.pack()
+
+# Save folder path
+tk.Label(app, text="Path to save folder:").pack()
+entry_save = tk.Entry(app, width=50)
+entry_save.pack()
+entry_save.bind("<KeyRelease>", on_entry_change)
+button_browse_save = tk.Button(app, text="Browse", command=lambda: browse_folder(entry_save))
+button_browse_save.pack()
+
+# New GUID selection
+tk.Label(app, text="New GUID:").pack()
+combo_new_guid = ttk.Combobox(app)
+combo_new_guid.pack()
+
+# Old GUID selection
+tk.Label(app, text="Old GUID:").pack()
+combo_old_guid = ttk.Combobox(app)
+combo_old_guid.pack()
+
+# Run command button
+run_button = tk.Button(app, text="Run Command", command=run_command)
+run_button.pack()
+
+load_config()
+
+app.mainloop()

--- a/gui.py
+++ b/gui.py
@@ -4,109 +4,119 @@ import subprocess
 import json
 import os
 
-config_file = "config.json"
-
+config_file = 'config.json'
 
 def browse_file(entry):
     filename = filedialog.askopenfilename()
-    entry.delete(0, tk.END)
-    entry.insert(0, filename)
-    save_config()
-
+    if filename != '':
+        entry.delete(0, tk.END)
+        entry.insert(0, filename)
+        save_config()
 
 def browse_folder(entry):
     foldername = filedialog.askdirectory()
-    entry.delete(0, tk.END)
-    entry.insert(0, foldername)
-    save_config()
-    update_guid_dropdowns(foldername)
+    if foldername != '':
+        entry.delete(0, tk.END)
+        entry.insert(0, foldername)
+        save_config()
+        update_guid_dropdowns()
 
-# remove the '.sav' extension
-def update_guid_dropdowns(folder_path):
-    players_folder = os.path.join(folder_path, "Players")
+# Remove the '.sav' extension.
+def update_guid_dropdowns():
+    folder_path = entry_save.get()
+    players_folder = os.path.join(folder_path, 'Players')
     if os.path.exists(players_folder) and os.path.isdir(players_folder):
-        # List all files and remove the '.sav' extension
+        # List all files and remove the '.sav' extension.
         file_names = [
             os.path.splitext(f)[0]
             for f in os.listdir(players_folder)
-            if os.path.isfile(os.path.join(players_folder, f)) and f.endswith(".sav")
+            if os.path.isfile(os.path.join(players_folder, f)) and f.endswith('.sav')
         ]
-        combo_new_guid["values"] = file_names
-        combo_old_guid["values"] = file_names
-
+        if not combo_new_guid.get() in file_names:
+            combo_new_guid.set('')
+        if not combo_old_guid.get() in file_names:
+            combo_old_guid.set('')
+        combo_new_guid['values'] = file_names
+        combo_old_guid['values'] = file_names
 
 def run_command():
     uesave_path = entry_uesave.get()
     save_path = entry_save.get()
     new_guid = combo_new_guid.get()
     old_guid = combo_old_guid.get()
+    guild_fix = guild_fix_var.get()
+    
     command = (
-        f'python fix-host-save.py "{uesave_path}" "{save_path}" {new_guid.replace(".sav", "")} {old_guid.replace(".sav", "")}'
+        f'python fix-host-save.py "{uesave_path}" "{save_path}" {new_guid.replace(".sav", "")} {old_guid.replace(".sav", "")} {guild_fix}'
     )
     subprocess.run(command, shell=True)
-
+    update_guid_dropdowns()
 
 def save_config():
     config = {
-        "uesave_path": entry_uesave.get(),
-        "save_path": entry_save.get(),
-        "new_guid": combo_new_guid.get(),
-        "old_guid": combo_old_guid.get(),
+        'uesave_path': entry_uesave.get(),
+        'save_path': entry_save.get(),
+        'new_guid': combo_new_guid.get(),
+        'old_guid': combo_old_guid.get(),
+        'guild_fix': guild_fix_var.get(),
     }
-    with open(config_file, "w") as f:
+    with open(config_file, 'w') as f:
         json.dump(config, f)
-
 
 def on_entry_change(event):
     save_config()
 
-
 def load_config():
     if os.path.exists(config_file):
-        with open(config_file, "r") as f:
+        with open(config_file, 'r') as f:
             config = json.load(f)
-            entry_uesave.insert(0, config.get("uesave_path", ""))
-            entry_save.insert(0, config.get("save_path", ""))
-            update_guid_dropdowns(config.get("save_path", ""))
-            combo_new_guid.set(config.get("new_guid", ""))
-            combo_old_guid.set(config.get("old_guid", ""))
-
+            entry_uesave.insert(0, config.get('uesave_path', ''))
+            entry_save.insert(0, config.get('save_path', ''))
+            update_guid_dropdowns()
+            combo_new_guid.set(config.get('new_guid', ''))
+            combo_old_guid.set(config.get('old_guid', ''))
+            guild_fix_var.set(config.get('guild_fix', ''))
 
 app = tk.Tk()
-app.title("Fix Host Save Command GUI")
+app.title('Fix Host Save Command GUI')
 
-# Uesave.exe path
-tk.Label(app, text="Path to uesave.exe:").pack()
+# Uesave.exe path.
+tk.Label(app, text='Path to uesave.exe:').pack()
 entry_uesave = tk.Entry(app, width=50)
 entry_uesave.pack()
-entry_uesave.bind("<KeyRelease>", on_entry_change)
+entry_uesave.bind('<KeyRelease>', on_entry_change)
 button_browse_uesave = tk.Button(
-    app, text="Browse", command=lambda: browse_file(entry_uesave)
+    app, text='Browse', command=lambda: browse_file(entry_uesave)
 )
 button_browse_uesave.pack()
 
-# Save folder path
-tk.Label(app, text="Path to save folder:").pack()
+# Save folder path.
+tk.Label(app, text='Path to save folder:').pack()
 entry_save = tk.Entry(app, width=50)
 entry_save.pack()
-entry_save.bind("<KeyRelease>", on_entry_change)
+entry_save.bind('<KeyRelease>', on_entry_change)
 button_browse_save = tk.Button(
-    app, text="Browse", command=lambda: browse_folder(entry_save)
+    app, text='Browse', command=lambda: browse_folder(entry_save)
 )
 button_browse_save.pack()
 
-# New GUID selection
-tk.Label(app, text="New GUID:").pack()
-combo_new_guid = ttk.Combobox(app)
+# New GUID selection.
+tk.Label(app, text='New GUID:').pack()
+combo_new_guid = ttk.Combobox(app, postcommand=update_guid_dropdowns)
 combo_new_guid.pack()
 
-# Old GUID selection
-tk.Label(app, text="Old GUID:").pack()
-combo_old_guid = ttk.Combobox(app)
+# Old GUID selection.
+tk.Label(app, text='Old GUID:').pack()
+combo_old_guid = ttk.Combobox(app, postcommand=update_guid_dropdowns)
 combo_old_guid.pack()
 
-# Run command button
-run_button = tk.Button(app, text="Run Command", command=run_command)
+# Guild fix selection.
+guild_fix_var = tk.BooleanVar()
+cb_guild_fix = tk.Checkbutton(app, text='Guild fix', variable=guild_fix_var, height=2)
+cb_guild_fix.pack()
+
+# Run command button.
+run_button = tk.Button(app, text='Run Command', command=run_command)
 run_button.pack()
 
 load_config()

--- a/gui.py
+++ b/gui.py
@@ -4,13 +4,15 @@ import subprocess
 import json
 import os
 
-config_file = 'config.json'
+config_file = "config.json"
+
 
 def browse_file(entry):
     filename = filedialog.askopenfilename()
     entry.delete(0, tk.END)
     entry.insert(0, filename)
     save_config()
+
 
 def browse_folder(entry):
     foldername = filedialog.askdirectory()
@@ -19,43 +21,56 @@ def browse_folder(entry):
     save_config()
     update_guid_dropdowns(foldername)
 
+# remove the '.sav' extension
 def update_guid_dropdowns(folder_path):
     players_folder = os.path.join(folder_path, "Players")
     if os.path.exists(players_folder) and os.path.isdir(players_folder):
-        file_names = [f for f in os.listdir(players_folder) if os.path.isfile(os.path.join(players_folder, f))]
-        combo_new_guid['values'] = file_names
-        combo_old_guid['values'] = file_names
+        # List all files and remove the '.sav' extension
+        file_names = [
+            os.path.splitext(f)[0]
+            for f in os.listdir(players_folder)
+            if os.path.isfile(os.path.join(players_folder, f)) and f.endswith(".sav")
+        ]
+        combo_new_guid["values"] = file_names
+        combo_old_guid["values"] = file_names
+
 
 def run_command():
     uesave_path = entry_uesave.get()
     save_path = entry_save.get()
     new_guid = combo_new_guid.get()
     old_guid = combo_old_guid.get()
-    command = f'python fix-host-save.py "{uesave_path}" "{save_path}" {new_guid} {old_guid}'
+    command = (
+        f'python fix-host-save.py "{uesave_path}" "{save_path}" {new_guid.replace(".sav", "")} {old_guid.replace(".sav", "")}'
+    )
     subprocess.run(command, shell=True)
+
 
 def save_config():
     config = {
-        'uesave_path': entry_uesave.get(),
-        'save_path': entry_save.get(),
-        'new_guid': combo_new_guid.get(),
-        'old_guid': combo_old_guid.get()
+        "uesave_path": entry_uesave.get(),
+        "save_path": entry_save.get(),
+        "new_guid": combo_new_guid.get(),
+        "old_guid": combo_old_guid.get(),
     }
-    with open(config_file, 'w') as f:
+    with open(config_file, "w") as f:
         json.dump(config, f)
+
 
 def on_entry_change(event):
     save_config()
 
+
 def load_config():
     if os.path.exists(config_file):
-        with open(config_file, 'r') as f:
+        with open(config_file, "r") as f:
             config = json.load(f)
-            entry_uesave.insert(0, config.get('uesave_path', ''))
-            entry_save.insert(0, config.get('save_path', ''))
-            update_guid_dropdowns(config.get('save_path', ''))
-            combo_new_guid.set(config.get('new_guid', ''))
-            combo_old_guid.set(config.get('old_guid', ''))
+            entry_uesave.insert(0, config.get("uesave_path", ""))
+            entry_save.insert(0, config.get("save_path", ""))
+            update_guid_dropdowns(config.get("save_path", ""))
+            combo_new_guid.set(config.get("new_guid", ""))
+            combo_old_guid.set(config.get("old_guid", ""))
+
 
 app = tk.Tk()
 app.title("Fix Host Save Command GUI")
@@ -65,7 +80,9 @@ tk.Label(app, text="Path to uesave.exe:").pack()
 entry_uesave = tk.Entry(app, width=50)
 entry_uesave.pack()
 entry_uesave.bind("<KeyRelease>", on_entry_change)
-button_browse_uesave = tk.Button(app, text="Browse", command=lambda: browse_file(entry_uesave))
+button_browse_uesave = tk.Button(
+    app, text="Browse", command=lambda: browse_file(entry_uesave)
+)
 button_browse_uesave.pack()
 
 # Save folder path
@@ -73,7 +90,9 @@ tk.Label(app, text="Path to save folder:").pack()
 entry_save = tk.Entry(app, width=50)
 entry_save.pack()
 entry_save.bind("<KeyRelease>", on_entry_change)
-button_browse_save = tk.Button(app, text="Browse", command=lambda: browse_folder(entry_save))
+button_browse_save = tk.Button(
+    app, text="Browse", command=lambda: browse_folder(entry_save)
+)
 button_browse_save.pack()
 
 # New GUID selection


### PR DESCRIPTION
## Summary
This pull request introduces a graphical user interface (GUI) addition to the existing Python command-line program. It aims to enhance user experience by providing a simple and intuitive way to interact with the tool's functionality.

## Changes
- Developed a Tkinter-based GUI for inputting command arguments.
- Implemented file and folder selection dialogs for easy path inputs.
- Added dynamic dropdowns for new and old GUID selections, populated based on the specified save folder.
- Ensured real-time configuration saving for user inputs.
- Aligned the GUI design with the existing command-line tool's functionalities.

## Impact
This enhancement makes the tool more accessible to users who prefer a graphical interface over command-line interactions. It simplifies the process of inputting arguments and selecting files, potentially increasing the tool's user base and improving overall usability.

## Tested using pyinstaller to turn into single file exe
- `pip install pyinstaller`
- `pyinstaller --onefile gui.py`

Looking forward to your feedback on this addition!


NOTE: I am a fullstack dev specializing in Javascript/Node and .Net Core. Please have mercy on my soul.