### PR TITLE
Fix/new save path

### DIFF
--- a/fix-host-save.py
+++ b/fix-host-save.py
@@ -66,11 +66,11 @@ of your save folder before continuing. Press enter if you would like to continue
         print('ERROR: Your given <save_path> of "' + save_path + '" does not exist. Did you enter the correct path to your save folder?')
         exit(1)
 
-    # Check if new GUID file already exists
-	if os.path.exists(new_sav_path):
-		print('ERROR: A file with the given <new_guid> does already exist. Please provide a free GUID')
-		exit(1)
-    
+    # Check if new GUID file already exist
+    if os.path.exists(new_sav_path):
+        print('ERROR: A file with the given <new_guid> does already exist. Please provide a free GUID')
+        exit(1)
+
     # Convert save files to JSON so it is possible to edit them.
     sav_to_json(uesave_path, level_sav_path)
     sav_to_json(uesave_path, old_sav_path)

--- a/fix-host-save.py
+++ b/fix-host-save.py
@@ -65,11 +65,11 @@ of your save folder before continuing. Press enter if you would like to continue
     if not os.path.exists(save_path):
         print('ERROR: Your given <save_path> of "' + save_path + '" does not exist. Did you enter the correct path to your save folder?')
         exit(1)
-    
-    # The player needs to have created a character on the dedicated server and that save is used for this script.
-    if not os.path.exists(new_sav_path):
-        print('ERROR: Your player save does not exist. Did you enter the correct new GUID of your player? It should look like "8E910AC2000000000000000000000000".\nDid your player create their character with the provided save? Once they create their character, a file called "' + new_sav_path + '" should appear. Look back over the steps in the README on how to get your new GUID.')
-        exit(1)
+
+    # Check if new GUID file already exists
+	if os.path.exists(new_sav_path):
+		print('ERROR: A file with the given <new_guid> does already exist. Please provide a free GUID')
+		exit(1)
     
     # Convert save files to JSON so it is possible to edit them.
     sav_to_json(uesave_path, level_sav_path)


### PR DESCRIPTION
Instead of checking if the new save file NOT existing (which gets deleted anyway later), it is now check if the file already exists and warns the user about the occurence.

From my understanding the `new_save_path` was only used to delete and then rename the old save file, after changes have been done, so the file itself wasn't necessary in the first place.