### PR TITLE
Update Palworld Save Tools to 0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To fix this bug, we've made a script that takes the GUID of the player on the ne
 
 Dependencies:
 - Python >=3.10
-- Install [Palworld Save Tools v0.17.1](https://github.com/cheahjs/palworld-save-tools) with `python -m pip install palworld-save-tools==0.17.1`
+- Install latest Palworld Save Tools [Palworld Save Tools v0.22.0](https://github.com/cheahjs/palworld-save-tools) with `python -m pip install palworld-save-tools==0.22.0`
 - Clone the repository with `git clone https://github.com/xNul/palworld-host-save-fix`
 
 Using the GUI:


### PR DESCRIPTION
This resolves the EOF error present in the older version. 

Updated with latest version of the dependent repo "Palworld Save Tools" latest tag 0.22.0 based on this issue: https://github.com/cheahjs/palworld-save-tools/issues/167